### PR TITLE
fix(nav): remove `overflow-y-scroll` when `lg`

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,5 +12,5 @@ import sitemap from "@astrojs/sitemap";
 // https://astro.build/config
 export default defineConfig({
   site: "https://avss2023.org",
-  integrations: [image(), sitemap(), tailwind()]
+  integrations: [image(), sitemap(), tailwind()],
 });

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -13,7 +13,7 @@ const { title, contents } = Astro.props;
   class="link-card flex flex-col justify-between overflow-hidden rounded-lg shadow-lg transition-shadow duration-500 ease-out hover:shadow-2xl"
 >
   <header
-    class="group flex items-center bg-primary px-6 py-4 text-2xl font-semibold text-neutral-100"
+    class="bg-primary group flex items-center px-6 py-4 text-2xl font-semibold text-neutral-100"
   >
     <div
       class="flex origin-left flex-row gap-2 transition-transform duration-150 ease-out group-focus-within:scale-110 group-hover:scale-110 group-focus:scale-110 group-active:scale-110"
@@ -23,7 +23,9 @@ const { title, contents } = Astro.props;
       </h2>
     </div>
   </header>
-  <div class="w-full divide-y-2 divide-neutral-300 bg-white py-2 px-3 text-sm grow">
+  <div
+    class="w-full grow divide-y-2 divide-neutral-300 bg-white py-2 px-3 text-sm"
+  >
     {
       contents.map((content) => (
         <div class="flex flex-col gap-2 px-2 py-4">

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -43,13 +43,6 @@ import NavItems from "./NavBar/NavItems.astro";
 
     const isOpen = () => menuBtn.dataset.open;
 
-    const resetAnimation = () => {
-      menuIcon.classList.remove("disappear", "appear");
-      closeIcon.classList.remove("disappear", "appear");
-      navbar.classList.remove("blur-in", "blur-out");
-      navList.classList.remove("fade-in", "fade-out");
-    };
-
     const toggleOpenState = () => {
       // the only dependency of this animation is isOpen state
       menuBtn.dataset.open = isOpen() === "false" ? "true" : "false";
@@ -61,8 +54,7 @@ import NavItems from "./NavBar/NavItems.astro";
         navbar.classList.remove("blur-out");
         navbar.classList.add("blur-in");
         navList.classList.remove("hidden");
-      }
-      else {
+      } else {
         closeIcon.classList.add("hidden");
         menuIcon.classList.remove("hidden");
 

--- a/src/components/NavBar/HoverNavItems.astro
+++ b/src/components/NavBar/HoverNavItems.astro
@@ -11,11 +11,10 @@ const { itemHover } = Astro.props as Props;
 
 const hasHover = itemHover && itemHover.length > 0;
 
-const mobileStyle =
-  "ml-6"
+const mobileStyle = "ml-6";
 const desktopBeforeInteration = "lg:pointer-events-none lg:opacity-0";
 const desktopAfterInteraction =
-"lg:absolute lg:top-10 lg:left-12 lg:w-56 lg:-translate-x-1/2 lg:rounded-lg lg:border-2 lg:bg-black/80 lg:px-4 lg:py-3 lg:shadow-lg";
+  "lg:absolute lg:top-10 lg:left-12 lg:w-56 lg:-translate-x-1/2 lg:rounded-lg lg:border-2 lg:bg-black/80 lg:px-4 lg:py-3 lg:shadow-lg";
 const desktopTransitionProperty = `
   lg:group-focus-within:pointer-events-auto
   lg:group-focus-within:block

--- a/src/components/NavBar/NavItems.astro
+++ b/src/components/NavBar/NavItems.astro
@@ -53,7 +53,7 @@ const { className } = Astro.props;
 ---
 
 <ul
-  class={"relative hidden divide-y-2 border-y-2 my-4 border-white overflow-y-scroll divide-white lg:my-0 lg:border-0 lg:divide-none grow flex-col items-center justify-end font-bold text-white lg:top-0 lg:flex lg:flex-row lg:gap-6 " +
+  class={"relative hidden divide-y-2 border-y-2 my-4 border-white overflow-y-scroll lg:overflow-visible divide-white lg:my-0 lg:border-0 lg:divide-none grow flex-col items-center justify-end font-bold text-white lg:top-0 lg:flex lg:flex-row lg:gap-6 " +
     className}
 >
   {


### PR DESCRIPTION
## What I did

- `NavItems` had `overflow-y-scroll` and it did when on `lg` view-width as well, causing weird `overflow-hidden` thing
- add `lg:overflow-visible` to make the hover item actually visible when `lg` view width